### PR TITLE
WIP Fix mutations visibility

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1779,8 +1779,20 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
         enumerate_print( wearing, c_blue );
     }
 
-    // @todo: Balance this formula
-    const int visibility_cap = g->u.get_per() - rl_dist( g->u.pos(), pos() );
+    // as of now, visibility of mutations is between 0 and 10
+    // 10 perception and 10 distance would see all mutations - cap 0
+    // 10 perception and 30 distance - cap 5, some mutations visible
+    // 3 perception and 3 distance would see all mutations - cap 0
+    // 3 perception and 15 distance - cap 5, some mutations visible
+    // 3 perception and 20 distance would be barely able to discern huge antlers on a person - cap 10
+    const int per = g->u.get_per();
+    const int dist = rl_dist( g->u.pos(), pos() );
+    int visibility_cap;
+    if( per <= 1) {
+        visibility_cap = INT_MAX;
+    } else {
+        visibility_cap = round( dist * dist / 20.0 / ( per - 1 ) );
+    }
 
     const auto trait_str = visible_mutations( visibility_cap );
     if( !trait_str.empty() ) {


### PR DESCRIPTION
SUMMARY: Bugfixes "Fix NPC mutations visibility threshold"

#### Purpose of change
NPC info hover popup did not show different NPC mutations depending on distance and perceptions -- it was broken before. This adds a working formula for mutation visibility threshold.

#### Describe the solution
I typed a lot of formulas into python interpreter and the one here kinda works, although it is not very transparent why.

#### Describe alternatives you've considered
Leaving it broken, because eh

#### Additional context
In the gif below I'm hovering over the tentacled NPC on the left. You can see how the list of visible mutations shrinks with increasing distance.
![mutations-ani](https://user-images.githubusercontent.com/159878/50553361-8874bd80-0ca5-11e9-814e-2dc58682def0.gif)

This mutation visibility cap ist not yet implemented for photos of NPCs. We both have beautiful beaks, if I could only hold on to theirs.